### PR TITLE
Rename app package and branding to MyGana

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # datmusic-android
 
-[<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" width="200">](https://play.google.com/store/apps/details?id=tm.alashow.datmusic)
+[<img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" width="200">](https://play.google.com/store/apps/details?id=com.mygana)
 
 ### Demo video & Screenshots
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ android {
 	compileSdkVersion = App.compileSdkVersion
 
 	defaultConfig {
-		namespace = "tm.alashow.datmusic"
+                namespace = "com.mygana"
 		applicationId = App.id
 		versionCode = App.versionCode
 		versionName = "${App.versionName}-${gitSha}"

--- a/app/google-services.json
+++ b/app/google-services.json
@@ -10,7 +10,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:182339910251:android:0471ac7b2dc78ac3",
         "android_client_info": {
-          "package_name": "tm.alashow.datmusic"
+          "package_name": "com.mygana"
         }
       },
       "oauth_client": [
@@ -18,7 +18,7 @@
           "client_id": "182339910251-datbtp2tvjb73datqfvi6u41b6n85s8c.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "tm.alashow.datmusic",
+            "package_name": "com.mygana",
             "certificate_hash": "6ec75dfd6a33d784aad67a7c31ab5e514e6aea1f"
           }
         },
@@ -26,7 +26,7 @@
           "client_id": "182339910251-lcah9j8gv6cujtvdufhtlb3gf5gfd8rc.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "tm.alashow.datmusic",
+            "package_name": "com.mygana",
             "certificate_hash": "4b375199270328a40f2a289c3c9a370fe0c740e5"
           }
         },
@@ -55,7 +55,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:182339910251:android:0471ac7b2dc78ac3",
         "android_client_info": {
-          "package_name": "tm.alashow.datmusic.debug"
+          "package_name": "com.mygana.debug"
         }
       },
       "oauth_client": [
@@ -63,7 +63,7 @@
           "client_id": "182339910251-datbtp2tvjb73datqfvi6u41b6n85s8c.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "tm.alashow.datmusic.debug",
+            "package_name": "com.mygana.debug",
             "certificate_hash": "6ec75dfd6a33d784aad67a7c31ab5e514e6aea1f"
           }
         },
@@ -71,7 +71,7 @@
           "client_id": "182339910251-lcah9j8gv6cujtvdufhtlb3gf5gfd8rc.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "tm.alashow.datmusic.debug",
+            "package_name": "com.mygana.debug",
             "certificate_hash": "4b375199270328a40f2a289c3c9a370fe0c740e5"
           }
         },
@@ -100,7 +100,7 @@
       "client_info": {
         "mobilesdk_app_id": "1:182339910251:android:0471ac7b2dc78ac3",
         "android_client_info": {
-          "package_name": "tm.alashow.datmusic.alpha"
+          "package_name": "com.mygana.alpha"
         }
       },
       "oauth_client": [
@@ -108,7 +108,7 @@
           "client_id": "182339910251-datbtp2tvjb73datqfvi6u41b6n85s8c.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "tm.alashow.datmusic.alpha",
+            "package_name": "com.mygana.alpha",
             "certificate_hash": "6ec75dfd6a33d784aad67a7c31ab5e514e6aea1f"
           }
         },
@@ -116,7 +116,7 @@
           "client_id": "182339910251-lcah9j8gv6cujtvdufhtlb3gf5gfd8rc.apps.googleusercontent.com",
           "client_type": 1,
           "android_info": {
-            "package_name": "tm.alashow.datmusic.alpha",
+            "package_name": "com.mygana.alpha",
             "certificate_hash": "4b375199270328a40f2a289c3c9a370fe0c740e5"
           }
         },

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -4,6 +4,6 @@
   -->
 
 <resources>
-    <string name="app_launcher">[D] Datmusic</string>
-    <string name="app_name">[D] Datmusic</string>
+    <string name="app_launcher">[D] MyGana</string>
+    <string name="app_name">[D] MyGana</string>
 </resources>

--- a/app/src/main/kotlin/tm/alashow/datmusic/notifications/Notifications.kt
+++ b/app/src/main/kotlin/tm/alashow/datmusic/notifications/Notifications.kt
@@ -19,7 +19,7 @@ import javax.inject.Inject
 import timber.log.Timber
 import tm.alashow.base.inititializer.AppInitializer
 import tm.alashow.base.util.extensions.orBlank
-import tm.alashow.datmusic.R
+import com.mygana.R
 import tm.alashow.datmusic.ui.buildArtistDetailsIntent
 import tm.alashow.datmusic.ui.buildSearchIntent
 

--- a/app/src/main/kotlin/tm/alashow/datmusic/ui/home/HomeNavigationItems.kt
+++ b/app/src/main/kotlin/tm/alashow/datmusic/ui/home/HomeNavigationItems.kt
@@ -13,7 +13,7 @@ import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.LibraryMusic
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material.icons.outlined.Settings
-import tm.alashow.datmusic.R
+import com.mygana.R
 import tm.alashow.navigation.screens.RootScreen
 
 internal val HomeNavigationItems = listOf(

--- a/app/src/main/play/products/premium_monthly.json
+++ b/app/src/main/play/products/premium_monthly.json
@@ -14,7 +14,7 @@
       "title": "Premium"
     }
   },
-  "packageName": "tm.alashow.datmusic",
+  "packageName": "com.mygana",
   "prices": {
     "AE": {
       "currency": "AED",

--- a/buildSrc/src/main/java/tm/alashow/buildSrc/App.kt
+++ b/buildSrc/src/main/java/tm/alashow/buildSrc/App.kt
@@ -1,7 +1,7 @@
 package tm.alashow.buildSrc
 
 object App {
-    const val id = "tm.alashow.datmusic"
+    const val id = "com.mygana"
 
     const val compileSdkVersion = 33
     const val targetSdkVersion = 33

--- a/modules/core-domain/src/main/java/tm/alashow/Config.kt
+++ b/modules/core-domain/src/main/java/tm/alashow/Config.kt
@@ -11,7 +11,7 @@ object Config {
     const val BASE_URL = "https://$BASE_HOST/"
     const val API_BASE_URL = "https://api-demo.$BASE_HOST/"
 
-    const val PLAYSTORE_ID = "tm.alashow.datmusic"
+    const val PLAYSTORE_ID = "com.mygana"
     const val PLAYSTORE_URL = "https://play.google.com/store/apps/details?id=$PLAYSTORE_ID"
 
     val API_TIMEOUT = Duration.ofSeconds(40).toMillis()

--- a/modules/i18n/src/main/res/values-de/app_strings.xml
+++ b/modules/i18n/src/main/res/values-de/app_strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">Datmusic</string>
-    <string name="app_launcher">Datmusic</string>
-    <string name="app_label">Datmusic</string>
+    <string name="app_name">MyGana</string>
+    <string name="app_launcher">MyGana</string>
+    <string name="app_label">MyGana</string>
 
     <string name="appBar.search.hint">Suche</string>
 

--- a/modules/i18n/src/main/res/values-es/app_strings.xml
+++ b/modules/i18n/src/main/res/values-es/app_strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_launcher">Datmusic</string>
-    <string name="app_label">Datmusic</string>
+    <string name="app_launcher">MyGana</string>
+    <string name="app_label">MyGana</string>
     <string name="search.title">Buscar</string>
     <string name="search.hint">Canciones, álbumes, artistas</string>
     <string name="search.hint.query">Consulta la busqueda</string>
@@ -12,7 +12,7 @@
     <string name="albums.detail.title">Álbum</string>
     <string name="audio.menu.cd">Menú de audio</string>
     <string name="audio.menu.play">Reproducir</string>
-    <string name="app_name">Datmusic</string>
+    <string name="app_name">MyGana</string>
     <string name="audio.menu.copyLink">Copiar enlace</string>
     <string name="search.minerva">Minerva</string>
     <string name="audio.menu.playNext">Reproducir Siguiente</string>

--- a/modules/i18n/src/main/res/values-fr/app_strings.xml
+++ b/modules/i18n/src/main/res/values-fr/app_strings.xml
@@ -49,14 +49,14 @@
     <string name="downloader.enqueue.audio.error.invalidUrl">Le lien de téléchargement est invalide</string>
     <string name="audio.menu.download">Télécharger</string>
     <string name="audio.menu.copyLink">Copier le lien</string>
-    <string name="app_name">Datmusic</string>
-    <string name="app_launcher">Datmusic</string>
+    <string name="app_name">MyGana</string>
+    <string name="app_launcher">MyGana</string>
     <string name="downloads.download.status.cancelled">Annulé</string>
     <string name="search.audios">Chansons</string>
     <string name="albums.detail.title">Album</string>
     <string name="audio.menu.cd">Menu audio</string>
     <string name="downloader.enqueue.downloadsLocationNotSelected">Aucun emplacement défini</string>
-    <string name="app_label">Datmusic</string>
+    <string name="app_label">MyGana</string>
     <string name="search.title">Rechercher</string>
     <string name="search.hint">Morceaux, albums, artistes</string>
     <string name="search.hint.query">Requête de recherche</string>

--- a/modules/i18n/src/main/res/values-ru/app_strings.xml
+++ b/modules/i18n/src/main/res/values-ru/app_strings.xml
@@ -23,7 +23,7 @@
     <string name="downloader.enqueue.audio.error.fileCreate">Не удалось создать файл в папке загрузок</string>
     <string name="downloader.enqueue.audio.existing.resuming">Возобновлена существующая загрузка</string>
     <string name="downloader.enqueue.audio.existing.alreadyQueued">Трек уже находится в очереди на скачивание</string>
-    <string name="app_name">Datmusic</string>
+    <string name="app_name">MyGana</string>
     <string name="downloader.enqueue.audio.existing.completed">Этот трек уже был загружен</string>
     <string name="downloader.enqueue.audio.existing.unknown">Запрос на загрузку существует, но имеет необработанный статус: %1$s</string>
     <string name="downloads.title">Загрузки</string>
@@ -71,8 +71,8 @@
     <string name="error.keyError">Ошибка ключа доступа, обновите приложение или свяжитесь разработчиком</string>
     <string name="error.unavailable">Помедленнее</string>
     <string name="captcha.reload">Перезагрузить</string>
-    <string name="app_launcher">Datmusic</string>
-    <string name="app_label">Datmusic</string>
+    <string name="app_launcher">MyGana</string>
+    <string name="app_label">MyGana</string>
     <string name="settings.title">Настройки</string>
     <string name="settings.theme">Тема</string>
     <string name="settings.theme.darkMode">Тёмный режим</string>

--- a/modules/i18n/src/main/res/values-tk/app_strings.xml
+++ b/modules/i18n/src/main/res/values-tk/app_strings.xml
@@ -25,7 +25,7 @@
     <string name="downloads.download.status.paused">Durdyrylan</string>
     <string name="downloads.download.status.queued">Nobatda</string>
     <string name="downloads.download.status.downloading">Indirilýar</string>
-    <string name="app_name">Datmusic</string>
+    <string name="app_name">MyGana</string>
     <string name="search.hint">Aýdymlar, albomlar, aýdymçylar</string>
     <string name="audio.menu.copyLink">Linki nusgala</string>
     <string name="downloader.downloadsLocationSelect.title">Indirme ýeri</string>
@@ -62,8 +62,8 @@
     <string name="captcha.empty">Kapça boş bolmaly däl</string>
     <string name="error.unavailable">Ýuwaşrak</string>
     <string name="error.keyError">Açar ýalňyşlygy, programmany täzeläň</string>
-    <string name="app_launcher">Datmusic</string>
-    <string name="app_label">Datmusic</string>
+    <string name="app_launcher">MyGana</string>
+    <string name="app_label">MyGana</string>
     <string name="downloads.download.status.failed">Şowsuz</string>
     <string name="downloads.download.status.cancelled">Ýatyryldy</string>
     <string name="downloads.download.pause">Duruz</string>

--- a/modules/i18n/src/main/res/values-tr/app_strings.xml
+++ b/modules/i18n/src/main/res/values-tr/app_strings.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_launcher">Datmusic</string>
-    <string name="app_label">Datmusic</string>
+    <string name="app_launcher">MyGana</string>
+    <string name="app_label">MyGana</string>
     <string name="search.minerva">Minerva</string>
-    <string name="app_name">Datmusic</string>
+    <string name="app_name">MyGana</string>
     <string name="settings.title">Ayarlar</string>
     <string name="settings.theme">Tema</string>
     <string name="settings.theme.darkMode">Karanlık mod</string>

--- a/modules/i18n/src/main/res/values/app_strings.xml
+++ b/modules/i18n/src/main/res/values/app_strings.xml
@@ -3,9 +3,9 @@
   All rights reserved.
   -->
 <resources>
-    <string name="app_name">Datmusic</string>
-    <string name="app_launcher">Datmusic</string>
-    <string name="app_label">Datmusic</string>
+    <string name="app_name">MyGana</string>
+    <string name="app_launcher">MyGana</string>
+    <string name="app_label">MyGana</string>
 
     <string name="appBar.search.hint">Search query</string>
 


### PR DESCRIPTION
## Summary
- update the application id to `com.mygana` and point the app module namespace at the new package
- rename the launcher/app strings to "MyGana" across locales and debug resources
- adjust Firebase, Play Billing config, and README references to use the new package id

## Testing
- ./gradlew :app:assembleDebug *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_68dcaa0a7f1c832a94c0a5cb1b35b199